### PR TITLE
Fix JSON failed parse input file on WSL

### DIFF
--- a/apifuzzer/utils.py
+++ b/apifuzzer/utils.py
@@ -146,7 +146,7 @@ def get_api_definition_from_file(src_file):
         with open(src_file, mode='rb') as f:
             api_definition = f.read()
         try:
-            return json.loads(api_definition)
+            return json.loads(api_definition.decode('utf-8'))
         except ValueError as e:
             print('Failed to load input as JSON, maybe YAML?')
         try:


### PR DESCRIPTION
Ubuntu on Widows (versioned Linux 4.4.0-18362-Microsoft #476-Microsoft Fri Nov 01 16:53:00 PST 2019 x86_64 x86_64 x86_64 GNU/Linux) was failing while opening any valid JSON file (no matter using local file or network) with error "Failed to parse input file, exit". This commit fixes it.